### PR TITLE
Update the default Argon2 options (#5788)

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -44,9 +44,9 @@ return [
     */
 
     'argon' => [
-        'memory' => 1024,
-        'threads' => 2,
-        'time' => 2,
+        'memory' => 65536,
+        'threads' => 1,
+        'time' => 4,
     ],
 
 ];


### PR DESCRIPTION
Update Laravel's default Argon2 options to the values used by PHP: https://github.com/php/php-src/blob/107997e58e922aadc6d5bd6777d42f52034f2ae6/ext/standard/php_password.h#L32